### PR TITLE
Fix production toml

### DIFF
--- a/fly-prod.toml
+++ b/fly-prod.toml
@@ -3,8 +3,7 @@
 #
 
 app = "audiobook-covers"
-primary_region = "sjc"
-swap_size_mb = 2048
+primary_region = "iad"
 
 [build]
 
@@ -14,7 +13,7 @@ force_https = true
 auto_stop_machines = "suspend"
 auto_start_machines = true
 min_machines_running = 0
-processes = ["app"]
+processes = ["web"]
 
 [http_service.concurrency]
 type = "requests"
@@ -28,11 +27,36 @@ method = "GET"
 timeout = "5s"
 path = "/api/heartbeat"
 
+[[services]]
+processes = ["clip"]
+internal_port = 8000
+protocol = "tcp"
+auto_start_machines = true
+auto_stop_machines = "suspend"
+min_machines_running = 0
+[[services.ports]]
+port = 8000
+concurrency = {type = "requests", soft_limit = 50, hard_limit = 100 }
+
 [[vm]]
+processes = ["web"]
 cpus = 1
 memory = "256mb"
 cpu_kind = "shared"
 
+[[vm]]
+processes = ["clip"]
+cpus = 1
+memory = "2gb"
+cpu_kind = "performance"
+
 [env]
 NODE_ENV = "production"
 ROARR_LOG = "true"
+
+[processes]
+web = "node /app/.output/server/index.mjs"
+clip = "/app/clip_server/.venv/bin/fastapi run /app/clip_server/main.py"
+
+[deploy]
+strategy = "immediate"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Deployment config changes can impact routing and availability: this introduces a new `clip` service/process and changes the primary region and process names used by `http_service`. Risk is moderate because misconfiguration could prevent machines from starting or expose the wrong ports.
> 
> **Overview**
> Updates `fly-prod.toml` to change the primary region to `iad` and rename the main `http_service` process from `app` to `web`.
> 
> Adds a separate `clip` process exposed on TCP `8000` with its own service definition, dedicated VM sizing (2GB/performance), and explicit `[processes]` commands for both `web` (Node server) and `clip` (FastAPI). Also sets deploy strategy to `immediate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25219a028a1be164d5b2ee9b352809f681bec029. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->