### PR TITLE
Redundant database analytics

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -80,16 +80,6 @@ CREATE TABLE session (
 
 CREATE INDEX idx_sessions_user_id ON session (user_id);
 
-CREATE TABLE analytics_event (
-    id BIGSERIAL PRIMARY KEY,
-    event_type TEXT NOT NULL,
-    payload JSONB NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE INDEX idx_analytics_event_type ON analytics_event(event_type);
-CREATE INDEX idx_analytics_event_created_at ON analytics_event(created_at);
-
 CREATE MATERIALIZED VIEW image_neighbor AS
     WITH complete_image AS (
         SELECT id, embedding_mobileclip_s0

--- a/src/routes/admin/database_info.tsx
+++ b/src/routes/admin/database_info.tsx
@@ -37,26 +37,9 @@ const getDatabaseStats = createServerFn().handler(async () => {
     LIMIT 10
   `;
 
-  const analyticsStats = await sqlTools.one(
-    z.object({
-      totalEvents: z.number(),
-      imageDeletedEvents: z.number(),
-      imageUndeletedEvents: z.number(),
-      recentEvents: z.number(),
-    }),
-  )`
-    SELECT
-      COUNT(*)::int AS totalEvents,
-      COUNT(*) FILTER (WHERE event_type = 'imageDeleted')::int AS imageDeletedEvents,
-      COUNT(*) FILTER (WHERE event_type = 'imageUndeleted')::int AS imageUndeletedEvents,
-      COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '7 days')::int AS recentEvents
-    FROM analytics_event
-  `;
-
   return {
     overall: overallStats,
     extensions: extensionStats,
-    analytics: analyticsStats,
   };
 });
 
@@ -118,35 +101,6 @@ function RouteComponent() {
               description={`${((ext.count / stats.overall.total) * 100).toFixed(1)}% of total`}
             />
           ))}
-        </div>
-      </section>
-
-      {/* Analytics Statistics */}
-      <section className="mb-6 sm:mb-8">
-        <h2 className="text-lg sm:text-xl font-semibold mb-4 text-slate-200">
-          Analytics Statistics
-        </h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-          <StatCard
-            title="Total Events"
-            value={stats.analytics.totalEvents}
-            description="All analytics events"
-          />
-          <StatCard
-            title="Image Deleted Events"
-            value={stats.analytics.imageDeletedEvents}
-            description="Times images were deleted"
-          />
-          <StatCard
-            title="Image Undeleted Events"
-            value={stats.analytics.imageUndeletedEvents}
-            description="Times images were restored"
-          />
-          <StatCard
-            title="Recent Events (7 days)"
-            value={stats.analytics.recentEvents}
-            description="Events in the last week"
-          />
         </div>
       </section>
     </div>

--- a/src/server/analytics.ts
+++ b/src/server/analytics.ts
@@ -1,4 +1,3 @@
-import { getDbConnection } from "@/server/db";
 import { z } from "zod/v4";
 import { createServerFn } from "@tanstack/react-start";
 import { waitUntil } from "cloudflare:workers";


### PR DESCRIPTION
Remove redundant database-side analytics features as PostHog now handles tracking.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-aef6c12f-6e0e-4057-af2b-080856837fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aef6c12f-6e0e-4057-af2b-080856837fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

