### PR TITLE
Public website API

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -19,11 +19,15 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as AdminIndexRouteImport } from './routes/admin/index'
 import { Route as ImagesIdRouteImport } from './routes/images.$id'
 import { Route as CoverBytextRouteImport } from './routes/cover.bytext'
+import { Route as ApiPublicRouteImport } from './routes/api.public'
 import { Route as ApiLoginRouteImport } from './routes/api/login'
 import { Route as AdminTestRouteImport } from './routes/admin/test'
 import { Route as AdminSimilarRouteImport } from './routes/admin/similar'
 import { Route as AdminLogoutRouteImport } from './routes/admin/logout'
 import { Route as AdminDatabase_infoRouteImport } from './routes/admin/database_info'
+import { Route as ApiPublicSearchRouteImport } from './routes/api.public.search'
+import { Route as ApiPublicRandomRouteImport } from './routes/api.public.random'
+import { Route as ApiPublicImagesIdRouteImport } from './routes/api.public.images.$id'
 
 const SearchRoute = SearchRouteImport.update({
   id: '/search',
@@ -75,6 +79,11 @@ const CoverBytextRoute = CoverBytextRouteImport.update({
   path: '/cover/bytext',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiPublicRoute = ApiPublicRouteImport.update({
+  id: '/api/public',
+  path: '/api/public',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiLoginRoute = ApiLoginRouteImport.update({
   id: '/api/login',
   path: '/api/login',
@@ -100,6 +109,21 @@ const AdminDatabase_infoRoute = AdminDatabase_infoRouteImport.update({
   path: '/database_info',
   getParentRoute: () => AdminRoute,
 } as any)
+const ApiPublicSearchRoute = ApiPublicSearchRouteImport.update({
+  id: '/search',
+  path: '/search',
+  getParentRoute: () => ApiPublicRoute,
+} as any)
+const ApiPublicRandomRoute = ApiPublicRandomRouteImport.update({
+  id: '/random',
+  path: '/random',
+  getParentRoute: () => ApiPublicRoute,
+} as any)
+const ApiPublicImagesIdRoute = ApiPublicImagesIdRouteImport.update({
+  id: '/images/$id',
+  path: '/images/$id',
+  getParentRoute: () => ApiPublicRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -114,9 +138,13 @@ export interface FileRoutesByFullPath {
   '/admin/similar': typeof AdminSimilarRoute
   '/admin/test': typeof AdminTestRoute
   '/api/login': typeof ApiLoginRoute
+  '/api/public': typeof ApiPublicRouteWithChildren
   '/cover/bytext': typeof CoverBytextRoute
   '/images/$id': typeof ImagesIdRoute
   '/admin/': typeof AdminIndexRoute
+  '/api/public/random': typeof ApiPublicRandomRoute
+  '/api/public/search': typeof ApiPublicSearchRoute
+  '/api/public/images/$id': typeof ApiPublicImagesIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -130,9 +158,13 @@ export interface FileRoutesByTo {
   '/admin/similar': typeof AdminSimilarRoute
   '/admin/test': typeof AdminTestRoute
   '/api/login': typeof ApiLoginRoute
+  '/api/public': typeof ApiPublicRouteWithChildren
   '/cover/bytext': typeof CoverBytextRoute
   '/images/$id': typeof ImagesIdRoute
   '/admin': typeof AdminIndexRoute
+  '/api/public/random': typeof ApiPublicRandomRoute
+  '/api/public/search': typeof ApiPublicSearchRoute
+  '/api/public/images/$id': typeof ApiPublicImagesIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -148,9 +180,13 @@ export interface FileRoutesById {
   '/admin/similar': typeof AdminSimilarRoute
   '/admin/test': typeof AdminTestRoute
   '/api/login': typeof ApiLoginRoute
+  '/api/public': typeof ApiPublicRouteWithChildren
   '/cover/bytext': typeof CoverBytextRoute
   '/images/$id': typeof ImagesIdRoute
   '/admin/': typeof AdminIndexRoute
+  '/api/public/random': typeof ApiPublicRandomRoute
+  '/api/public/search': typeof ApiPublicSearchRoute
+  '/api/public/images/$id': typeof ApiPublicImagesIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -167,9 +203,13 @@ export interface FileRouteTypes {
     | '/admin/similar'
     | '/admin/test'
     | '/api/login'
+    | '/api/public'
     | '/cover/bytext'
     | '/images/$id'
     | '/admin/'
+    | '/api/public/random'
+    | '/api/public/search'
+    | '/api/public/images/$id'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -183,9 +223,13 @@ export interface FileRouteTypes {
     | '/admin/similar'
     | '/admin/test'
     | '/api/login'
+    | '/api/public'
     | '/cover/bytext'
     | '/images/$id'
     | '/admin'
+    | '/api/public/random'
+    | '/api/public/search'
+    | '/api/public/images/$id'
   id:
     | '__root__'
     | '/'
@@ -200,9 +244,13 @@ export interface FileRouteTypes {
     | '/admin/similar'
     | '/admin/test'
     | '/api/login'
+    | '/api/public'
     | '/cover/bytext'
     | '/images/$id'
     | '/admin/'
+    | '/api/public/random'
+    | '/api/public/search'
+    | '/api/public/images/$id'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -214,6 +262,7 @@ export interface RootRouteChildren {
   RandomRoute: typeof RandomRoute
   SearchRoute: typeof SearchRoute
   ApiLoginRoute: typeof ApiLoginRoute
+  ApiPublicRoute: typeof ApiPublicRouteWithChildren
   CoverBytextRoute: typeof CoverBytextRoute
   ImagesIdRoute: typeof ImagesIdRoute
 }
@@ -290,6 +339,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CoverBytextRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/public': {
+      id: '/api/public'
+      path: '/api/public'
+      fullPath: '/api/public'
+      preLoaderRoute: typeof ApiPublicRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/login': {
       id: '/api/login'
       path: '/api/login'
@@ -325,6 +381,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminDatabase_infoRouteImport
       parentRoute: typeof AdminRoute
     }
+    '/api/public/search': {
+      id: '/api/public/search'
+      path: '/search'
+      fullPath: '/api/public/search'
+      preLoaderRoute: typeof ApiPublicSearchRouteImport
+      parentRoute: typeof ApiPublicRoute
+    }
+    '/api/public/random': {
+      id: '/api/public/random'
+      path: '/random'
+      fullPath: '/api/public/random'
+      preLoaderRoute: typeof ApiPublicRandomRouteImport
+      parentRoute: typeof ApiPublicRoute
+    }
+    '/api/public/images/$id': {
+      id: '/api/public/images/$id'
+      path: '/images/$id'
+      fullPath: '/api/public/images/$id'
+      preLoaderRoute: typeof ApiPublicImagesIdRouteImport
+      parentRoute: typeof ApiPublicRoute
+    }
   }
 }
 
@@ -346,6 +423,22 @@ const AdminRouteChildren: AdminRouteChildren = {
 
 const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
 
+interface ApiPublicRouteChildren {
+  ApiPublicRandomRoute: typeof ApiPublicRandomRoute
+  ApiPublicSearchRoute: typeof ApiPublicSearchRoute
+  ApiPublicImagesIdRoute: typeof ApiPublicImagesIdRoute
+}
+
+const ApiPublicRouteChildren: ApiPublicRouteChildren = {
+  ApiPublicRandomRoute: ApiPublicRandomRoute,
+  ApiPublicSearchRoute: ApiPublicSearchRoute,
+  ApiPublicImagesIdRoute: ApiPublicImagesIdRoute,
+}
+
+const ApiPublicRouteWithChildren = ApiPublicRoute._addFileChildren(
+  ApiPublicRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
@@ -355,6 +448,7 @@ const rootRouteChildren: RootRouteChildren = {
   RandomRoute: RandomRoute,
   SearchRoute: SearchRoute,
   ApiLoginRoute: ApiLoginRoute,
+  ApiPublicRoute: ApiPublicRouteWithChildren,
   CoverBytextRoute: CoverBytextRoute,
   ImagesIdRoute: ImagesIdRoute,
 }

--- a/src/routes/api.public.images.$id.ts
+++ b/src/routes/api.public.images.$id.ts
@@ -1,0 +1,36 @@
+import { getImageByIdAndSimilar } from "@/server/imageSearcher";
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod/v4";
+
+export const Route = createFileRoute("/api/public/images/$id")({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        const parsedId = z.uuid().safeParse(params.id);
+        if (!parsedId.success) {
+          return Response.json(
+            { error: 'Invalid image id. Expected UUID in path parameter "id".' },
+            { status: 400 },
+          );
+        }
+
+        const images = await getImageByIdAndSimilar({ data: parsedId.data });
+        if (images.length === 0) {
+          return Response.json({ error: "Image not found." }, { status: 404 });
+        }
+
+        const [image, ...similar] = images;
+        return Response.json({
+          image,
+          similar,
+          totalSimilar: similar.length,
+          similarity: {
+            metric: "cosine_distance",
+            field: "distance",
+            order: "ascending (smaller is more similar)",
+          },
+        });
+      },
+    },
+  },
+});

--- a/src/routes/api.public.random.ts
+++ b/src/routes/api.public.random.ts
@@ -1,0 +1,16 @@
+import { getRandom } from "@/server/imageSearcher";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/public/random")({
+  server: {
+    handlers: {
+      GET: async () => {
+        const images = await getRandom();
+        return Response.json({
+          images,
+          total: images.length,
+        });
+      },
+    },
+  },
+});

--- a/src/routes/api.public.search.ts
+++ b/src/routes/api.public.search.ts
@@ -1,0 +1,30 @@
+import { vectorSearchByString } from "@/server/imageSearcher";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/public/search")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const q = new URL(request.url).searchParams.get("q");
+        if (q === null) {
+          return Response.json(
+            { error: 'Missing required query parameter "q".' },
+            { status: 400 },
+          );
+        }
+
+        const images = await vectorSearchByString({ data: { q } });
+        return Response.json({
+          query: q,
+          images,
+          total: images.length,
+          similarity: {
+            metric: "cosine_distance",
+            field: "distance",
+            order: "ascending (smaller is more similar)",
+          },
+        });
+      },
+    },
+  },
+});

--- a/src/routes/api.public.ts
+++ b/src/routes/api.public.ts
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/public")({
+  server: {
+    handlers: {
+      GET: async () => {
+        return Response.json({
+          name: "Audiobook Covers Public API",
+          version: 1,
+          endpoints: {
+            random: "/api/public/random",
+            search: "/api/public/search?q=<query>",
+            image: "/api/public/images/<image-id>",
+          },
+          similarity: {
+            metric: "cosine_distance",
+            field: "distance",
+            order: "ascending (smaller is more similar)",
+          },
+        });
+      },
+    },
+  },
+});


### PR DESCRIPTION
Adds a new `/api/public` endpoint group to expose public website interactions (random browse, text search, image details with similarity) for new API consumers.

This new API provides a modern alternative to the legacy `cover.bytext.ts` endpoint, leveraging existing TanStack server functions and including cosine distance for search similarity, without modifying core server logic.

---
<p><a href="https://cursor.com/agents?id=bc-a55f0f83-306d-4ae6-bf9f-ad644689fc51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a55f0f83-306d-4ae6-bf9f-ad644689fc51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

