### PR TITLE
Route tree regen command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ All packages are managed using pnpm.
 | --------------------- | ------------------------------------------------------------------------- |
 | `just build`          | Build the app and check for type errors (use this after making changes)   |
 | `just types`          | Regenerate Wrangler/Cloudflare Worker types (`worker-configuration.d.ts`) |
+| `just regen-route-tree` | Regenerate TanStack route tree (`src/routeTree.gen.ts`) once           |
 | `just dev`            | Start the dev server (see below)                                          |
 | `just preview`        | Preview the production build locally                                      |
 | `just deploy`         | Build and deploy to Cloudflare (development env)                          |
@@ -25,7 +26,7 @@ Database migration recipes (`db_migrate`, `db_migrate_force`, `prod_db_migrate`,
 ## Do not run the dev server
 
 **In general Agents must not start or keep a dev server running.**
-You never need to start a dev server when interacting with a human. The human will have a dev server running, and if they do not, you can remind them to start one. When building a pull request without the help of a human, it can be helpful to run a dev server in certain circumstances. A dev server for tanstack start will automatically rebuild the generated routeTree.gen.ts file. You may need to run a dev server temporarily to rebuild this file.
+You never need to start a dev server when interacting with a human. The human will have a dev server running, and if they do not, you can remind them to start one. If you need to regenerate the TanStack route tree, run `just regen-route-tree` instead of starting a dev server.
 
 ## After making changes
 

--- a/Justfile
+++ b/Justfile
@@ -10,6 +10,9 @@ preview:
 types:
     pnpm exec wrangler types
 
+regen-route-tree:
+    pnpm exec tsx regen_route_tree.ts
+
 reindex-images:
     pnpm exec tsx reindex_images.ts
 

--- a/regen_route_tree.ts
+++ b/regen_route_tree.ts
@@ -1,0 +1,76 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { Generator, getConfig } from "@tanstack/router-generator";
+
+function toImportPath(fromFile: string, absolutePath: string): string {
+  let relativePath = path.relative(path.dirname(fromFile), absolutePath);
+
+  if (!relativePath.startsWith(".")) {
+    relativePath = `./${relativePath}`;
+  }
+
+  // ESM import paths must use POSIX separators.
+  return relativePath.split(path.sep).join("/");
+}
+
+function findFirstExistingFile(root: string, candidates: Array<string>): string | null {
+  for (const candidate of candidates) {
+    const absolutePath = path.resolve(root, candidate);
+    if (existsSync(absolutePath)) {
+      return absolutePath;
+    }
+  }
+
+  return null;
+}
+
+async function main() {
+  const root = process.cwd();
+  const baseConfig = getConfig({}, root);
+  const generatedRouteTreePath = path.resolve(baseConfig.generatedRouteTree);
+
+  const routerFilePath = findFirstExistingFile(root, [
+    "src/router.tsx",
+    "src/router.ts",
+    "src/router.jsx",
+    "src/router.js",
+  ]);
+
+  if (!routerFilePath) {
+    throw new Error(
+      "Could not locate the router file. Expected one of: src/router.tsx, src/router.ts, src/router.jsx, src/router.js",
+    );
+  }
+
+  const startFilePath = findFirstExistingFile(root, [
+    "src/start.tsx",
+    "src/start.ts",
+    "src/start.jsx",
+    "src/start.js",
+  ]);
+
+  const moduleDeclarationLines = [
+    `import type { getRouter } from '${toImportPath(generatedRouteTreePath, routerFilePath)}'`,
+    startFilePath
+      ? `import type { startInstance } from '${toImportPath(generatedRouteTreePath, startFilePath)}'`
+      : "import type { createStart } from '@tanstack/react-start'",
+    "declare module '@tanstack/react-start' {",
+    "  interface Register {",
+    "    ssr: true",
+    "    router: Awaited<ReturnType<typeof getRouter>>",
+    ...(startFilePath
+      ? ["    config: Awaited<ReturnType<typeof startInstance.getOptions>>"]
+      : []),
+    "  }",
+    "}",
+  ];
+
+  const routeTreeFileFooter = [moduleDeclarationLines.join("\n")];
+
+  const config = getConfig({ routeTreeFileFooter }, root);
+  const generator = new Generator({ config, root });
+  await generator.run();
+}
+
+await main();


### PR DESCRIPTION
Add `just regen-route-tree` command to regenerate the TanStack Start route tree without a dev server.

The standard `tsr generate` command was found to strip TanStack Start-specific type registrations from `routeTree.gen.ts`. This PR introduces a custom script that programmatically generates the route tree and correctly injects the necessary Start module augmentation footer, ensuring the regenerated file matches the dev server's output.

---
<p><a href="https://cursor.com/agents?id=bc-f9de18c1-3d81-4a7e-aea9-53206107fe66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9de18c1-3d81-4a7e-aea9-53206107fe66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

